### PR TITLE
Add CI and deployment workflows for frontend

### DIFF
--- a/.github/workflows/ci-frontend.yml
+++ b/.github/workflows/ci-frontend.yml
@@ -1,0 +1,78 @@
+name: CI Frontend
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  build-and-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: carambolo-doces
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: carambolo-doces/package-lock.json
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test -- --watch=false
+
+      - name: Build
+        run: npm run build
+
+  build-and-push-image:
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    needs: build-and-test
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js (para cache de dependências se quiser usar em builds locais)
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Login to container registry
+        env:
+          REGISTRY_HOST: ${{ secrets.REGISTRY_HOST }}
+          REGISTRY_USERNAME: ${{ secrets.REGISTRY_USERNAME }}
+          REGISTRY_PASSWORD: ${{ secrets.REGISTRY_PASSWORD }}
+        run: |
+          if [ -z "$REGISTRY_USERNAME" ] || [ -z "$REGISTRY_PASSWORD" ]; then
+            echo "Registro não configurado (REGISTRY_USERNAME/REGISTRY_PASSWORD). Pulando push de imagem."
+            exit 0
+          fi
+          if [ -n "$REGISTRY_HOST" ]; then
+            echo "$REGISTRY_PASSWORD" | docker login "$REGISTRY_HOST" -u "$REGISTRY_USERNAME" --password-stdin
+          else
+            echo "$REGISTRY_PASSWORD" | docker login -u "$REGISTRY_USERNAME" --password-stdin
+          fi
+
+      - name: Build and push frontend image
+        working-directory: ./carambolo-doces
+        env:
+          FRONTEND_IMAGE: ${{ secrets.FRONTEND_IMAGE }}
+        run: |
+          IMAGE="${FRONTEND_IMAGE:-teiko/frontend:latest}"
+          echo "Construindo imagem $IMAGE ..."
+          docker build -f ../docker/Dockerfile -t "$IMAGE" ..
+          if docker info >/dev/null 2>&1; then
+            docker push "$IMAGE"
+          fi
+
+

--- a/.github/workflows/deploy-frontend.yml
+++ b/.github/workflows/deploy-frontend.yml
@@ -1,0 +1,49 @@
+name: Deploy Frontend to EC2
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: "Ambiente de destino (ex: lab, prod)"
+        required: false
+        default: "lab"
+
+jobs:
+  deploy-frontend:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout (somente para referência)
+        uses: actions/checkout@v4
+
+      - name: Deploy frontend em EC2 públicas
+        uses: appleboy/ssh-action@v1.2.0
+        with:
+          host: ${{ secrets.FRONTEND_EC2_HOSTS }}
+          username: ${{ secrets.FRONTEND_EC2_USER }}
+          key: ${{ secrets.FRONTEND_EC2_SSH_KEY }}
+          script: |
+            set -euo pipefail
+
+            echo "[ci-frontend] Preparando /opt/teiko..."
+            sudo mkdir -p /opt/teiko
+            sudo chown -R "$USER":"$USER" /opt/teiko
+            cd /opt/teiko
+
+            # Atualiza/clona infra
+            if [ -d infra ]; then
+              sudo git -C infra fetch --all --prune || true
+              sudo git -C infra reset --hard origin/main || true
+            else
+              sudo git clone https://github.com/Teiko-org/infra.git infra
+            fi
+
+            cd /opt/teiko
+
+            echo "[ci-frontend] Rodando setup-aws-public.sh (frontend + proxy /api)..."
+            FORCE_INFRA_UPDATE=1 \
+            FORCE_FRONT_UPDATE=1 \
+            sudo -E bash /opt/teiko/infra/aws-ec2/setup-aws-public.sh
+
+
+

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,35 @@
+FROM node:20-alpine AS build
+WORKDIR /app
+
+# Evita downloads/avisos desnecessários no build
+ENV BROWSERSLIST_IGNORE_OLD_DATA=true \
+    npm_config_audit=false \
+    npm_config_fund=false \
+    npm_config_loglevel=warn
+
+# Instala primeiro somente manifestos para cache eficaz
+COPY ./carambolo-doces/package*.json ./
+
+# Instala dependências (inclui opcionais para rollup) com cache
+RUN npm ci --include=optional --no-audit --no-fund || npm install --include=optional --no-audit --no-fund
+# Garante binário musl do Rollup no Alpine
+RUN npm i -D @rollup/rollup-linux-x64-musl --no-save || true
+
+# Copia o código depois para aproveitar cache de deps
+COPY ./carambolo-doces ./
+
+# Build mais rápido (sem minificação nem sourcemap)
+RUN npm run build -- --minify=false --sourcemap=false
+
+# Runtime leve (Node para servir via Express)
+FROM node:20-alpine
+WORKDIR /app
+ENV NODE_ENV=production
+RUN npm init -y && npm i express http-proxy-middleware
+COPY ./docker/server.js /app/server.js
+COPY --from=build /app/dist /app/dist
+EXPOSE 8080
+CMD ["node", "server.js"]
+
+
+

--- a/docker/server.js
+++ b/docker/server.js
@@ -1,0 +1,58 @@
+const express = require('express');
+const path = require('path');
+const { createProxyMiddleware, responseInterceptor } = require('http-proxy-middleware');
+
+const app = express();
+const port = 8080;
+
+const upstreamEnv = process.env.API_UPSTREAMS || '';
+const upstreams = upstreamEnv.split(',').map(s => s.trim()).filter(Boolean);
+if (upstreams.length === 0) {
+  console.error('[frontend] API_UPSTREAMS não definido. Ex.: API_UPSTREAMS=10.0.2.203:8080,10.0.3.46:8080');
+  process.exit(1);
+}
+
+let rr = 0;
+const pick = () => `http://${upstreams[(rr++) % upstreams.length]}`;
+
+// Static files (Vite build)
+const distDir = path.join(__dirname, 'dist');
+app.use(express.static(distDir));
+
+// Proxy /api com round-robin por requisição, logs, timeouts e reescrita de URLs absolutas
+app.use('/api', (req, res, next) => {
+  const target = pick();
+  console.log(`[proxy] ${req.method} ${req.url} -> ${target}`);
+  return createProxyMiddleware({
+    target,
+    changeOrigin: true,
+    xfwd: true,
+    logLevel: 'debug',
+    timeout: 15000,
+    proxyTimeout: 15000,
+    pathRewrite: { '^/api': '' },
+    selfHandleResponse: true,
+    onProxyRes: responseInterceptor(async (buffer, proxyRes) => {
+      const ct = String(proxyRes.headers['content-type'] || '').toLowerCase();
+      if (ct.includes('application/json') || ct.includes('text/')) {
+        let body = buffer.toString('utf8');
+        body = body.replace(/http:\/\/localhost:8080\/?/gi, '/api/');
+        body = body.replace(/http:\/\/10\.\d+\.\d+\.\d+:8080\/?/gi, '/api/');
+        return body;
+      }
+      return buffer;
+    }),
+    onProxyReq: (proxyReq) => {
+      proxyReq.setHeader('Connection', 'keep-alive');
+    },
+  })(req, res, next);
+});
+
+// SPA fallback
+app.get(/^(?!\/api).*/, (_req, res) => res.sendFile(path.join(distDir, 'index.html')));
+
+app.listen(port, () => console.log(`[frontend] Servindo em http://0.0.0.0:${port} | UPSTREAMS: ${upstreams.join(', ')}`));
+
+
+
+


### PR DESCRIPTION
- Introduced a CI workflow for building, testing, and pushing the frontend Docker image to a container registry.
- Added a deployment workflow for deploying the frontend to EC2 instances, with SSH access and environment configuration.
- Created a Dockerfile for building the frontend application and serving it via an Express server.
- Implemented a server.js file to handle static file serving and API proxying with round-robin load balancing.