### PR TITLE
Hide browser progress bars and loading indicators across the application

### DIFF
--- a/carambolo-doces/src/index.css
+++ b/carambolo-doces/src/index.css
@@ -186,3 +186,43 @@ body { padding-bottom: 0 !important; }
 .custom-scrollbar::-webkit-scrollbar-thumb:hover {
   background-color: #0F2A3D;
 }
+
+/* Esconder barra de progresso do navegador */
+progress {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  height: 0 !important;
+  width: 0 !important;
+  position: absolute !important;
+  left: -9999px !important;
+}
+
+/* Esconder qualquer barra de progresso na parte inferior */
+body > progress,
+html > progress,
+#root > progress,
+[role="progressbar"],
+.progress-bar,
+.loading-bar,
+.browser-progress {
+  display: none !important;
+  visibility: hidden !important;
+  opacity: 0 !important;
+  height: 0 !important;
+  width: 0 !important;
+  position: absolute !important;
+  left: -9999px !important;
+}
+
+/* Esconder barra de progresso do navegador (Chrome/Edge) */
+body::after,
+html::after {
+  content: none !important;
+}
+
+/* Esconder qualquer elemento fixo na parte inferior que possa ser barra de progresso */
+[style*="bottom"][style*="progress"],
+[style*="bottom"][style*="loading"] {
+  display: none !important;
+}


### PR DESCRIPTION
- Added CSS rules to completely hide the browser's progress bar and any loading indicators.
- Ensured that progress elements are not displayed or visible in the DOM, improving the overall user experience.
- Included specific styles to target various progress elements and fixed-position indicators.