### PR TITLE
Add phone validation utility import in FormContext

### DIFF
--- a/carambolo-doces/src/contexts/FormContext.jsx
+++ b/carambolo-doces/src/contexts/FormContext.jsx
@@ -2,6 +2,7 @@ import React, { createContext, useState } from 'react';
 import { useForm, FormProvider as RHFProvider } from 'react-hook-form';
 import { axiosApi } from '../provider/AxiosApi';
 import { toast } from 'react-toastify';
+import { validateBrazilianPhone } from '../utils/phoneValidation';
 
 export const FormContext = createContext();
 


### PR DESCRIPTION
- Imported `validateBrazilianPhone` utility to enhance phone number validation capabilities within the FormContext.
- This addition sets the stage for improved user input handling across forms that require phone number validation.